### PR TITLE
Group fix to remove root privs

### DIFF
--- a/02-nonrootuser/Dockerfile
+++ b/02-nonrootuser/Dockerfile
@@ -2,7 +2,7 @@ FROM radiantone/fid:7.4.4
 
 # Provide a non-root user to run the process.
 RUN groupadd --gid 1000 radiantone && \
-    useradd --uid 1000 --gid 1000 -G 0 \
+    useradd --uid 1000 --gid 1000 \
       --home-dir /opt/radiantone --no-create-home \
       radiantone
 
@@ -19,4 +19,3 @@ WORKDIR /opt/radiantone
 # Override the entrypoint
 ENTRYPOINT ["/opt/radiantone/run.sh"]
 CMD ["log"]
-

--- a/02-nonrootuser/Dockerfile_zk
+++ b/02-nonrootuser/Dockerfile_zk
@@ -2,7 +2,7 @@ FROM radiantone/zookeeper:3.5.8
 
 # Provide a non-root user to run the process.
 RUN groupadd --gid 1000 radiantone && \
-    useradd --uid 1000 --gid 1000 -G 0 \
+    useradd --uid 1000 --gid 1000 \
       --home-dir /opt/radiantone --no-create-home \
       radiantone
 


### PR DESCRIPTION
Group 0 isn't necessary for ZK or FID to run based on initial tests, we should remove it to enforce least privilege.